### PR TITLE
Ham: Enable Hw Keys Overlay from Lollipop

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -18,6 +18,9 @@
 -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- HW keys prefs-->  
+    <bool name="config_hwKeysPref">true</bool>
+    
     <!-- Hardware 'face' keys present on the device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each
          of the following keys present:


### PR DESCRIPTION
Recently users are reporting no hw keys disabling or backlight not being set. This is not a bug, maintainers are missing necessary bools in device config.xml

Please, check this out. https://github.com/ResurrectionRemix-Devices/android_device_oneplus_bacon/commit/31c44600c9947fb740399e2d72d147bbc6d2f6e1

We miss u in zuk z1 MrColdBird!
