### PR TITLE
Revert "Ham: Enable Hw Keys Overlay from Lollipop"

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -18,9 +18,6 @@
 -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- HW keys prefs-->  
-    <bool name="config_hwKeysPref">true</bool>
-    
     <!-- Hardware 'face' keys present on the device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each
          of the following keys present:


### PR DESCRIPTION
Reverts MrColdbird/android_device_zuk_ham#2 as it breaks the CM build process.
